### PR TITLE
Fix adding duplicate overlays when reverting buffer and in general

### DIFF
--- a/scopeline.el
+++ b/scopeline.el
@@ -95,13 +95,16 @@
 
 (defun scopeline--add-overlay (pos text)
   "Add overlay at `POS' with the specified `TEXT'."
+  (dolist (ov (overlays-in pos pos))
+    (when (overlay-get ov 'scopeline)
+      (setq scopeline--overlays (delete ov scopeline--overlays))
+      (delete-overlay ov)))
   (let ((ov (make-overlay pos pos)))
     (overlay-put ov 'after-string
                  (propertize (format "%s%s" scopeline-overlay-prefix text)
                              'face 'scopeline-face))
-    ;; FIXME: If we have overlays at the same point, it does not get
-    ;; added multiple times to the list but does get shown multiple
-    ;; times in the buffer
+    ;; Mark this overlay as belonging to scopeline
+    (overlay-put ov 'scopeline t)
     (add-to-list 'scopeline--overlays ov)))
 
 (defun scopeline--delete-all-overlays ()


### PR DESCRIPTION
When a buffer is reverted (or when the major mode is reloaded), buffer local variables are cleared, but overlays aren't. This causes previously added overlays to linger around.

This PR marks all overlays added by scopeline with a property, and makes it so that if we attempt to add a duplicate overlay, the previously added ones would be deleted instead.

This does not make delete-all-overlays also eagerly look through every overlay in the buffer and try to clean them up, because that seems slow and unnecessary.