### PR TITLE
Change `scopeline-targets` for `nix` to `binding`

### DIFF
--- a/scopeline.el
+++ b/scopeline.el
@@ -81,7 +81,7 @@
     (json-mode . ("pair"))
     (toml-mode . ("pair"))
     (mhtml-mode . ("element"))
-    (nix-mode . ("bind"))
+    (nix-mode . ("binding"))
     (python-mode . ("function_definition" "if_statement" "for_statement"))
     (rust-mode . ("function_item" "for_expression" "if_expression"))
     (sh-mode . ("function_definition" "if_statement" "while_statement" "for_statement" "case_statement"))


### PR DESCRIPTION
`bind` did not work for me.  Looking at `tree-sitter-nix`, [it looks like there was a refactor in May 2022](https://github.com/nix-community/tree-sitter-nix/commit/14af97221e59b355e421f71f94bf302f860267a8).

Setting `nix-mode`'s value to `binding` fixed it for me.