### PR TITLE
Adding ruby-mode declarations

### DIFF
--- a/scopeline.el
+++ b/scopeline.el
@@ -83,7 +83,7 @@
     (mhtml-mode . ("element"))
     (nix-mode . ("bind"))
     (python-mode . ("function_definition" "if_statement" "for_statement"))
-    (ruby-mode . ("block" "case" "do_block" "if" "method" "singleton_method" "unless"))
+    (ruby-mode . ("block" "case" "do_block" "if" "method" "singleton_method" "unless" "class"))
     (rust-mode . ("function_item" "for_expression" "if_expression"))
     (sh-mode . ("function_definition" "if_statement" "while_statement" "for_statement" "case_statement"))
     (yaml-mode . ("block_mapping_pair")))

--- a/scopeline.el
+++ b/scopeline.el
@@ -83,6 +83,7 @@
     (mhtml-mode . ("element"))
     (nix-mode . ("bind"))
     (python-mode . ("function_definition" "if_statement" "for_statement"))
+    (ruby-mode . ("block" "case" "do_block" "if" "method" "singleton_method" "unless"))
     (rust-mode . ("function_item" "for_expression" "if_expression"))
     (sh-mode . ("function_definition" "if_statement" "while_statement" "for_statement" "case_statement"))
     (yaml-mode . ("block_mapping_pair")))


### PR DESCRIPTION
With the following ruby code:

```ruby
class Hello
  def self.world
    if true
      (0..3).each { |e| }
    end
  end

  def world
    [].each do |i|
    end

    unless false
    end

    case stuff
    end
  end
end
```

We have the results of `treesit-explore-mode`:

```
(program
 (class class name: (constant)
  (body_statement
   (singleton_method def object: (self) . body: (identifier)
    (body_statement
     (if if condition: (true)
      consequence:
       (then
	(call
	 method:
	  (parenthesized_statements (
	   (range begin: (integer) operator: .. end: (integer))
	   ))
	 block: . (identifier)
	 (block {
	  parameters: (block_parameters | (identifier) |)
	  })))
      end))
    end)
   (method def body: (identifier)
    (body_statement
     (call
      method: (array [ ])
      block: . (identifier)
      (do_block do
       parameters: (block_parameters | (identifier) |)
       end))
     (unless unless condition: (false) end)
     (case case value: (identifier) end))
    end))
  body: end))
```